### PR TITLE
Move terraform dep versions to top level projects

### DIFF
--- a/infra/tf/versions.tf
+++ b/infra/tf/versions.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "6.45.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.9.0"
+    }
+  }
+}


### PR DESCRIPTION
This seems like best practice and was also causing issues with renovate
otherwise.

Versions are now specified in the prod and test modules instead of the
shared module.
